### PR TITLE
Fix subtitle generation for long texts and expose subtitle download

### DIFF
--- a/packages/backend/src/services/tts.stream.service.ts
+++ b/packages/backend/src/services/tts.stream.service.ts
@@ -209,7 +209,8 @@ async function buildSegment(params: TTSParams, task: Task, dir: string = '') {
     headers: {
       'content-type': 'application/octet-stream',
       'x-generate-tts-type': 'stream',
-      'Access-Control-Expose-Headers-generate-tts-id': task.id,
+      'x-generate-tts-id': task.id,
+      'Access-Control-Expose-Headers': 'x-generate-tts-type, x-generate-tts-id',
     },
     fileName: segment.id,
     onError: (err) => `Custom error: ${err.message}`,
@@ -237,16 +238,28 @@ export async function handleSrt(audioPath: string, stream = true) {
     await generateSrt(tempJsonPath, audioPath.replace('.mp3', '.srt'))
     return
   }
-  const { dir, base } = path.parse(audioPath)
+  const { base } = path.parse(audioPath)
   const tmpDir = audioPath + '_tmp'
   await ensureDir(tmpDir)
 
-  const fileList = (await readdir(tmpDir))
-    .filter((file) => file.includes(base) && file.includes('.json'))
-    .sort((a, b) => Number(a.split('.json.')?.[1] || 0) - Number(b.split('.json.')?.[1] || 0))
-    .map((file) => path.join(tmpDir, file))
+  const collectFiles = async () =>
+    (await readdir(tmpDir))
+      .filter((file) => file.includes(base) && file.includes('.json'))
+      .sort(
+        (a, b) =>
+          Number(a.split('.json.')?.[1] || 0) - Number(b.split('.json.')?.[1] || 0),
+      )
+      .map((file) => path.join(tmpDir, file))
+
+  let fileList: string[] = []
+  let retries = 5
+  while (retries-- > 0 && fileList.length === 0) {
+    fileList = await collectFiles()
+    if (fileList.length) break
+    await asyncSleep(200)
+  }
   if (!fileList.length) return
-  concatDirSrt({ jsonFiles: fileList, inputDir: tmpDir, outputFile: audioPath })
+  await concatDirSrt({ jsonFiles: fileList, inputDir: tmpDir, outputFile: audioPath })
 }
 async function buildSegmentList(segments: BuildSegment[], task: Task): Promise<void> {
   const { res, segment } = task.context as Required<NonNullable<Task['context']>>
@@ -266,7 +279,8 @@ async function buildSegmentList(segments: BuildSegment[], task: Task): Promise<v
     headers: {
       'content-type': 'application/octet-stream',
       'x-generate-tts-type': 'stream',
-      'Access-Control-Expose-Headers-generate-tts-id': task.id,
+      'x-generate-tts-id': task.id,
+      'Access-Control-Expose-Headers': 'x-generate-tts-type, x-generate-tts-id',
     },
     onError: (err) => `Custom error: ${err.message}`,
     fileName: segment.id,

--- a/packages/frontend/src/api/tts.ts
+++ b/packages/frontend/src/api/tts.ts
@@ -91,7 +91,7 @@ export const createTask = async (data: TaskRequest) => {
   return response.data
 }
 
-export const createTaskStream = async (data: TaskRequest) => {
+export const createTaskStream = async (data: GenerateRequest) => {
   const response = await api.post<ReadableStream | ResponseWrapper<GenerateResponse>>(
     `/createStream`,
     data,
@@ -99,10 +99,11 @@ export const createTaskStream = async (data: TaskRequest) => {
       responseType: 'stream',
       adapter: 'fetch',
       timeout: 0,
-    }
+    },
   )
   const ttsType = response.headers['x-generate-tts-type']
   const contentType = response.headers['content-type']
+  const taskId = response.headers['x-generate-tts-id']
   if (
     response.status !== 200 ||
     ttsType === 'application/json' ||
@@ -110,9 +111,9 @@ export const createTaskStream = async (data: TaskRequest) => {
   ) {
     const text = await new Response(response.data as any).text()
     const responseData = JSON.parse(text)
-    return responseData
+    return { data: responseData, taskId }
   }
-  return response.data as ReadableStream
+  return { stream: response.data as ReadableStream, taskId }
 }
 
 export const downloadFile = (file: string) => `${api.defaults.baseURL}/download/${file}`

--- a/packages/frontend/src/views/Generate.vue
+++ b/packages/frontend/src/views/Generate.vue
@@ -255,6 +255,7 @@ import StreamButton from '@/components/StreamButton.vue'
 import {
   generateTTS,
   getVoiceList,
+  getTask,
   type Voice,
   type GenerateResponse,
   createTaskStream,
@@ -602,12 +603,13 @@ const generateAudioTask = async () => {
 
   try {
     const params = buildParams(inputText)
-    const stream = await createTaskStream(params)
+    const { stream, data, taskId } = await createTaskStream(params)
+    if (data?.code && data.data) {
+      updateAudioList(data.data)
+      return
+    }
     if (!(stream instanceof ReadableStream)) {
-      if (stream.code && stream.data) {
-        updateAudioList(stream.data)
-        return
-      }
+      throw new Error('Stream not returned')
     }
     console.log('typeof stream:', typeof stream)
     console.log('stream instanceof ReadableStream :', stream instanceof ReadableStream)
@@ -628,7 +630,7 @@ const generateAudioTask = async () => {
       }
       generationStore.updateProgress(progress.increase())
     }
-    const onFinished = (newAudioUrl: string, blobs: Blob[]) => {
+    const onFinished = async (newAudioUrl: string, blobs: Blob[]) => {
       audioPlayerRef.value!.audioRef!.src = newAudioUrl
       const name = `${params.voice}-${params.text.slice(0, 10)}-${Date.now()}`
       generating.value = false
@@ -639,8 +641,28 @@ const generateAudioTask = async () => {
         name,
         blobs,
       }
+      const index = generationStore.audioList.length
       generationStore.updateProgress(100)
       updateAudioList(result)
+      if (taskId) {
+        let attempts = 5
+        while (attempts-- > 0) {
+          try {
+            const taskRes = await getTask({ id: taskId })
+            const taskResult = taskRes.data?.result
+            if (taskResult?.srt) {
+              const newList = [...generationStore.audioList]
+              newList[index].srt = taskResult.srt
+              newList[index].file = taskResult.file || newList[index].file
+              generationStore.updateAudioList(newList)
+              break
+            }
+          } catch (err) {
+            console.error('getTask error', err)
+          }
+          await asyncSleep(1000)
+        }
+      }
       audioPlayerRef.value!.audioRef?.addEventListener(
         'loadedmetadata',
         () => {


### PR DESCRIPTION
## Summary
- wait for subtitle chunks before merging and expose task id headers in TTS stream
- return task id from createTaskStream API
- poll backend for generated SRT and show download button after long-text generation

## Testing
- `pnpm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68be8bb2a71c8325bbf4d9db3730f6d2